### PR TITLE
Fix order of link states in css. Change color of visited links.

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -45,9 +45,9 @@ h3 {
   margin-top: 1em;
   margin-bottom: 1em; }
 
-a:hover,
 a:visited,
 a:link,
+a:hover,
 a:active {
   text-decoration: none; }
 
@@ -748,12 +748,12 @@ main {
 .page_news .one_news_block {
   margin: 40px 10%; }
   .page_news .one_news_block a {
-    color: #ff6c00;
+    color: #ff6600;
     transition: all 0.4s; }
-  .page_news .one_news_block a:hover {
-    color: #ff6c00; }
   .page_news .one_news_block a:visited {
-    color: #642b00; }
+    color: #727579; }
+  .page_news .one_news_block a:hover {
+    color: #ff6600; }
   .page_news .one_news_block strong {
     color: #ddddde; }
   .page_news .one_news_block li {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -45,9 +45,9 @@ h3 {
   margin-top: 1em;
   margin-bottom: 1em; }
 
-a:hover,
 a:visited,
 a:link,
+a:hover,
 a:active {
   text-decoration: none; }
 
@@ -748,12 +748,12 @@ main {
 .page_news .one_news_block {
   margin: 40px 10%; }
   .page_news .one_news_block a {
-    color: #ff6c00;
+    color: #ff6600;
     transition: all 0.4s; }
-  .page_news .one_news_block a:hover {
-    color: #ff6c00; }
   .page_news .one_news_block a:visited {
-    color: #642b00; }
+    color: #727579; }
+  .page_news .one_news_block a:hover {
+    color: #ff6600; }
   .page_news .one_news_block strong {
     color: #ddddde; }
   .page_news .one_news_block li {


### PR DESCRIPTION
1. Fix hover in links. It wasn't work.
There are 4 link states: a:active, a:hover, a:visited, and a:link.
To avoid behavior overlapping, these states should go in the following order:
a:hover should go after a:link and a:visited.
a:active should go after a:hover.
2. Change hovered links color #ff6c00 -> #727579